### PR TITLE
options.transport not set to expanded var form

### DIFF
--- a/lib/GraphQL/Client/CLI.pm
+++ b/lib/GraphQL/Client/CLI.pm
@@ -138,6 +138,7 @@ sub _get_options {
 
     my $transport = eval { _expand_vars($options{transport}) };
     die "Two or more --transport keys are incompatible.\n" if $@;
+    $options{transport} = $transport if ref $transport eq 'HASH' && %$transport;
 
     if (ref $options{variables}) {
         $options{variables} = eval { _expand_vars($options{variables}) };

--- a/t/cli.t
+++ b/t/cli.t
@@ -44,6 +44,29 @@ subtest 'get_options' => sub {
     }
 };
 
+subtest 'get_options_transport' => sub {
+    my $expected = {
+        format          => 'json:pretty',
+        filter          => undef,
+        help            => undef,
+        manual          => undef,
+        operation_name  => undef,
+        outfile         => undef,
+        query           => 'bar',
+        transport       => { headers => {'X-Test' => 'value', 'X-Test-2' => 'val2' } },
+        unpack          => 0,
+        url             => 'foo',
+        variables       => undef,
+        version         => undef,
+    };
+
+    my $r = GraphQL::Client::CLI->_get_options(qw{--url foo --query bar --transport headers.X-Test=value --transport headers.X-Test-2=val2});
+    is_deeply($r, $expected, '--url, --query set option and correctly expanded transport options') or diag explain $r;
+};
+
+
+
+
 subtest 'expand_vars' => sub {
     my $r = GraphQL::Client::CLI::_expand_vars({
         'foo.bar'       => 'baz',


### PR DESCRIPTION
When passing transport options to graphql CLI client (f.e. `graphql --url http://localhost/graphql --query '{hello}' --transport headers.X-API-Key=somesecret`  the expanded form using '.' is parsed but not set, making it impossible to use f.e. headers with the provided client:

t/cli-transport.t
```
#!/usr/bin/env perl

use warnings;
use strict;

use Test::Exception;
use Test::More;

use GraphQL::Client::CLI;

delete $ENV{GRAPHQL_CLIENT_OPTIONS};

subtest 'get_options_transport' => sub {
    my $expected = {
        format          => 'json:pretty',
        filter          => undef,
        help            => undef,
        manual          => undef,
        operation_name  => undef,
        outfile         => undef,
        query           => 'bar',
        transport       => { headers => {'X-Test' => 'value', 'X-Test-2' => 'val2' } },
        unpack          => 0,
        url             => 'foo',
        variables       => undef,
        version         => undef,
    };

    my $r = GraphQL::Client::CLI->_get_options(qw{--url foo --query bar --transport headers.X-Test=value --transport headers.X-Test-2=val2});
    is_deeply($r, $expected, '--url, --query set option and correctly expanded transport options') or diag explain $r;
};

done_testing;
```

```
$ prove -v  t/cli-transport.t 
t/cli-transport.t .. 
# Subtest: get_options_transport
    not ok 1 - --url, --query set option and correctly expanded transport options

    #   Failed test '--url, --query set option and correctly expanded transport options'
    #   at t/cli-transport.t line 30.
    #     Structures begin differing at:
    #          $got->{transport}{headers.X-Test-2} = 'val2'
    #     $expected->{transport}{headers.X-Test-2} = Does not exist
    # {
    #   'filter' => undef,
    #   'format' => 'json:pretty',
    #   'help' => undef,
    #   'manual' => undef,
    #   'operation_name' => undef,
    #   'outfile' => undef,
    #   'query' => 'bar',
    #   'transport' => {
    #     'headers.X-Test' => 'value',
    #     'headers.X-Test-2' => 'val2'
    #   },
    #   'unpack' => 0,
    #   'url' => 'foo',
    #   'variables' => undef,
    #   'version' => undef
    # }
    1..1
    # Looks like you failed 1 test of 1.
not ok 1 - get_options_transport

#   Failed test 'get_options_transport'
#   at t/cli-transport.t line 31.
1..1
# Looks like you failed 1 test of 1.
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/1 subtests 

Test Summary Report
-------------------
t/cli-transport.t (Wstat: 256 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
Files=1, Tests=1,  0 wallclock secs ( 0.01 usr  0.01 sys +  0.06 cusr  0.01 csys =  0.09 CPU)
Result: FAIL
```

Updated lib/GraphQL/Client/CLI.pm to set the expanded var form of transport options in the options.   Added a test (the one above) to t/cli.t


